### PR TITLE
Increase timeout to 5 minutes for the gradle compile

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/AbstractCompilationLocal.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/AbstractCompilationLocal.java
@@ -212,7 +212,7 @@ public abstract class AbstractCompilationLocal {
         
         logger.info("Issuing Command: " + buildCommand);
         
-        String managerBuildResults = getLinuxImage().getCommandShell().issueCommand(buildCommand);
+        String managerBuildResults = getLinuxImage().getCommandShell().issueCommand(buildCommand, 300000);
         
         assertThat(managerBuildResults).contains("BUILD SUCCESSFUL");
         logger.info("OUTPUT FOR TEST: " + managerBuildResults);


### PR DESCRIPTION
Signed-off-by: Michael Baylis <Michael.Baylis@uk.ibm.com>