### PR TITLE
disabling RSE tests from codecoverage until they are reliable

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuRse.java
@@ -3,7 +3,6 @@
  */
 package dev.galasa.inttests.zosBatch.local;
 
-import dev.galasa.Tags;
 import dev.galasa.Test;
 import dev.galasa.TestAreas;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
@@ -21,7 +20,7 @@ import dev.galasa.zos.ZosImage;
 
 @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
-@Tags({"codecoverage"})
+//@Tags({"codecoverage"}) - disabled until rse stable
 public class ZosBatchLocalJava11UbuntuRse extends AbstractZosBatchLocalRSE {
 
     @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY")

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuRse.java
@@ -3,7 +3,6 @@
  */
 package dev.galasa.inttests.zosFile.local;
 
-import dev.galasa.Tags;
 import dev.galasa.Test;
 import dev.galasa.TestAreas;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
@@ -21,7 +20,7 @@ import dev.galasa.zos.ZosImage;
 
 @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
-@Tags({"codecoverage"})
+//@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosFileLocalJava11UbuntuRse extends AbstractZosFileLocalRSE {
 
     @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY")

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuRse.java
@@ -3,7 +3,6 @@
  */
 package dev.galasa.inttests.zosFileDataset.local;
 
-import dev.galasa.Tags;
 import dev.galasa.Test;
 import dev.galasa.TestAreas;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
@@ -21,7 +20,7 @@ import dev.galasa.zos.ZosImage;
 
 @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
-@Tags({"codecoverage"})
+//@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosFileDatasetLocalJava11UbuntuRse extends AbstractZosFileDatasetLocalRSE {
 
     @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY")

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuRse.java
@@ -3,7 +3,6 @@
  */
 package dev.galasa.inttests.zosVSAM.local;
 
-import dev.galasa.Tags;
 import dev.galasa.Test;
 import dev.galasa.TestAreas;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
@@ -21,7 +20,7 @@ import dev.galasa.zos.ZosImage;
 
 @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
-@Tags({"codecoverage"})
+//@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosVSAMLocalJava11UbuntuRse extends AbstractZosVSAMLocalRSE {
 
     @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY")


### PR DESCRIPTION
Signed-off-by: Michael Baylis <Michael.Baylis@uk.ibm.com>