### PR TITLE
uplift dependency on galasa framework to 0.26.0 instead of 0,.25.0

### DIFF
--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -87,7 +87,7 @@ subprojects {
 
     dependencies {
         compileOnly 'dev.galasa:dev.galasa:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.framework:0.25.0'
+        compileOnly 'dev.galasa:dev.galasa.framework:0.26.0'
         compileOnly 'dev.galasa:dev.galasa.core.manager:0.25.0'
         compileOnly 'dev.galasa:dev.galasa.zos.manager:0.25.0'
         compileOnly 'dev.galasa:dev.galasa.ipnetwork.manager:0.21.0'


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
