### PR TITLE
Remove Docker integrated tests - Issue 1386

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/local/DockerLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/local/DockerLocalJava11Ubuntu.java
@@ -17,7 +17,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"dockermanager", "localecosystem", "java11", "ubuntu"})
 @Tags({"codecoverage"})
 public class DockerLocalJava11Ubuntu extends AbstractDockerUbuntuLocal {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/local/DockerLocalJava16Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/local/DockerLocalJava16Ubuntu.java
@@ -16,7 +16,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"dockermanager", "localecosystem", "java16", "ubuntu"})
 public class DockerLocalJava16Ubuntu extends AbstractDockerUbuntuLocal {
 	


### PR DESCRIPTION
Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>

Removing the Docker integrated tests from the schedule for now, as they are causing the regression-run job as a whole to get stuck. They are also retrying multiple times, which is filling up galasa-prod with Pods. I will be investigating the problem with these tests and I will add back to the schedule once I have fixed them.

https://github.com/galasa-dev/projectmanagement/issues/1386