### PR TITLE
simbank integration test should not insist that .gradle is checked-in to simbank repo. Create folder dynamically

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/AbstractCompilationLocalSimBank.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/AbstractCompilationLocalSimBank.java
@@ -121,12 +121,9 @@ public abstract class AbstractCompilationLocalSimBank extends AbstractCompilatio
                 simplatformParent.resolve(testProjectName)
             );    
         
-        // Get /.gradle
-        logger.trace("Copying /.gradle into parent directory");
-        moveFilesOnRemote(
-                unpackedDir.resolve("simplatform-main/galasa-simbank-tests/.gradle"), 
-                simplatformParent.resolve(".gradle")
-            );    
+        // Create an empty gradle home folder, so we can add a properties files to it to control the build.
+        logger.trace("Creating an empty .gradle in the parent directory so we have a home for gradle properties.");
+        mkdirOnRemote( simplatformParent.resolve(".gradle") );    
     }
 
     /*
@@ -157,6 +154,13 @@ public abstract class AbstractCompilationLocalSimBank extends AbstractCompilatio
      */
     private void moveFilesOnRemote(Path source, Path target) throws IpNetworkManagerException, LinuxManagerException {
         String command = "mv " + source.toString() + " " + target.toString() + "; echo RC=$?";
+        logger.info("issuing command: " + command);
+        String rc = getLinuxImage().getCommandShell().issueCommand(command);
+        assertThat(rc).isEqualToIgnoringWhitespace("RC=0");
+    }
+
+    private void mkdirOnRemote(Path target) throws IpNetworkManagerException, LinuxManagerException {
+        String command = "mkdir -p " + target.toString() + "; echo RC=$?";
         logger.info("issuing command: " + command);
         String rc = getLinuxImage().getCommandShell().issueCommand(command);
         assertThat(rc).isEqualToIgnoringWhitespace("RC=0");


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

See issue [Inttest failure : .gradle needs to be checked-in !#1645](https://github.com/galasa-dev/projectmanagement/issues/1645)