### PR TITLE
Iss1736 - Updating Docker registry to harbor.galasa.dev to remove harbor-cicsk8s dependency

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
@@ -37,9 +37,9 @@ public abstract class AbstractDocker {
 
 		// TODO: remove hard coded values
 		getEcosystem().setCpsProperty("docker.default.registries", "HARBOR,PROXY");
-		getEcosystem().setCpsProperty("docker.registry.HARBOR.url", "https://harbor-cicsk8s.hursley.ibm.com");
-		getEcosystem().setCpsProperty("docker.registry.PROXY.url", "https://harbor-cicsk8s.hursley.ibm.com");
-		getEcosystem().setCpsProperty("docker.registry.PROXY.image.prefix", "dockerhub");
+		getEcosystem().setCpsProperty("docker.registry.HARBOR.url", "https://harbor.galasa.dev");
+		getEcosystem().setCpsProperty("docker.registry.PROXY.url", "https://harbor.galasa.dev");
+		getEcosystem().setCpsProperty("docker.registry.PROXY.image.prefix", "docker_proxy_cache");
 	}
 	
 	@Test

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,9 +1,9 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.26.0
+galasaVersion=0.32.0
 galasaSourceCompatibility=11
 galasaTargetCompatibility=11
 
-sourceMaven=https://development.galasa.dev/main/maven-repo/obr
+sourceMaven=https://repo.maven.apache.org/maven2/
 centralMaven=https://repo.maven.apache.org/maven2/
 targetMaven=https://repo.maven.apache.org/maven2/

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,9 +1,9 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.25.0
+galasaVersion=0.26.0
 galasaSourceCompatibility=11
 galasaTargetCompatibility=11
 
-sourceMaven=https://repo.maven.apache.org/maven2/
+sourceMaven=https://development.galasa.dev/main/maven-repo/obr
 centralMaven=https://repo.maven.apache.org/maven2/
 targetMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
- Experimenting to see if we can pull images from harbor.galasa.dev instead of harbor-cicsk8s for the DockerManager test.
- Also updated galasaVersion in gradle.properties but not entirely sure this is actually used.