### PR TITLE
correcting the maven plugin 'catatlog' typo

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
+++ b/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
@@ -10,8 +10,8 @@
 
 	<properties>
 		<galasa.test.stream>inttests</galasa.test.stream>
-		<galasa.skip.bundletestcatatlog>true</galasa.skip.bundletestcatatlog>
-		<galasa.skip.deploytestcatatlog>true</galasa.skip.deploytestcatatlog>
+		<galasa.skip.bundletestcatalog>true</galasa.skip.bundletestcatalog>
+		<galasa.skip.deploytestcatalog>true</galasa.skip.deploytestcatalog>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Signed-off-by: Fiona Ampofo <64271621+Akyiaa@users.noreply.github.com>
Story: https://github.com/galasa-dev/projectmanagement/issues/1755

