### PR TITLE
Uplift versions of galasa plugins used. Use the bom for dependency versions

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -125,7 +125,7 @@ function gradle_build {
     ${CONSOLE_FLAG} \
     --warning-mode=all \
     -Dorg.gradle.java.home=${JAVA_HOME} \
-    -PsourceMaven=https://development.galasa.dev/main/maven-repo/managers ${OPTIONAL_DEBUG_FLAG} \
+    -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr ${OPTIONAL_DEBUG_FLAG} \
     -PcentralMaven=https://repo.maven.apache.org/maven2/ \
     publish publishToMavenLocal \
     "
@@ -144,7 +144,7 @@ function publish_artifacts {
     bootstrap=https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
     cmd="mvn \
-    -Dgalasa.source.repo=https://development.galasa.dev/main/maven-repo/managers \
+    -Dgalasa.source.repo=https://development.galasa.dev/main/maven-repo/obr \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
     -Dgalasa.release.repo=file://$BASEDIR/temp \
     -Dgalasa.bootstrap=${bootstrap} \

--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'dev.galasa.githash' version '0.15.0' apply false
-    id 'dev.galasa.testcatalog' version '0.15.0' apply false
-    id 'dev.galasa.tests' version '0.15.0' apply false
+    id 'dev.galasa.githash' version '0.33.0' apply false
+    id 'dev.galasa.testcatalog' version '0.33.0' apply false
+    id 'dev.galasa.tests' version '0.33.0' apply false
 }
 
 subprojects {
@@ -86,26 +86,28 @@ subprojects {
  //   }
 
     dependencies {
-        compileOnly 'dev.galasa:dev.galasa:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.framework:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.core.manager:0.31.0'
-        compileOnly 'dev.galasa:dev.galasa.zos.manager:0.31.0'
-        compileOnly 'dev.galasa:dev.galasa.ipnetwork.manager:0.25.0'
-        compileOnly 'dev.galasa:dev.galasa.http.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.artifact.manager:0.25.0'
-        compileOnly 'dev.galasa:dev.galasa.linux.manager:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.windows.manager:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.openstack.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.kubernetes.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.docker.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.galasaecosystem.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.java.manager:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.java.ubuntu.manager:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.java.windows.manager:0.21.0'
-        compileOnly 'dev.galasa:dev.galasa.sem.manager:0.25.0'
-        compileOnly 'dev.galasa:dev.galasa.cicsts.manager:0.32.0'
-        compileOnly 'dev.galasa:dev.galasa.zosprogram.manager:0.25.0'
-        compileOnly 'dev.galasa:dev.galasa.githubissue.manager:0.31.0'
+        implementation platform('dev.galasa:galasa-bom:0.33.0')
+
+        compileOnly 'dev.galasa:dev.galasa'
+        compileOnly 'dev.galasa:dev.galasa.framework'
+        compileOnly 'dev.galasa:dev.galasa.core.manager'
+        compileOnly 'dev.galasa:dev.galasa.zos.manager'
+        compileOnly 'dev.galasa:dev.galasa.ipnetwork.manager'
+        compileOnly 'dev.galasa:dev.galasa.http.manager'
+        compileOnly 'dev.galasa:dev.galasa.artifact.manager'
+        compileOnly 'dev.galasa:dev.galasa.linux.manager'
+        compileOnly 'dev.galasa:dev.galasa.windows.manager'
+        compileOnly 'dev.galasa:dev.galasa.openstack.manager'
+        compileOnly 'dev.galasa:dev.galasa.kubernetes.manager'
+        compileOnly 'dev.galasa:dev.galasa.docker.manager'
+        compileOnly 'dev.galasa:dev.galasa.galasaecosystem.manager'
+        compileOnly 'dev.galasa:dev.galasa.java.manager'
+        compileOnly 'dev.galasa:dev.galasa.java.ubuntu.manager'
+        compileOnly 'dev.galasa:dev.galasa.java.windows.manager'
+        compileOnly 'dev.galasa:dev.galasa.sem.manager'
+        compileOnly 'dev.galasa:dev.galasa.cicsts.manager'
+        compileOnly 'dev.galasa:dev.galasa.zosprogram.manager'
+        compileOnly 'dev.galasa:dev.galasa.githubissue.manager'
         compileOnly 'commons-logging:commons-logging:1.2'
         compileOnly 'org.assertj:assertj-core:3.11.0'
         compileOnly 'javax.validation:validation-api:2.0.1.Final'

--- a/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
+++ b/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>dev.galasa.inttests.obr</artifactId>
-	<version>0.32.0</version>
+	<version>0.33.0</version>
 	<packaging>galasa-obr</packaging>
 
 	<properties>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.inttests</artifactId>
-			<version>0.32.0</version>
+			<version>0.33.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-maven-plugin</artifactId>
-				<version>0.32.0</version>
+				<version>0.33.0</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/galasa-inttests-parent/dev.galasa.inttests/build.gradle
+++ b/galasa-inttests-parent/dev.galasa.inttests/build.gradle
@@ -5,9 +5,11 @@ plugins {
 
 description = 'Galasa Integration Tests'
 
-version = '0.32.0'
+version = '0.33.0'
 
 dependencies {
+    implementation platform('dev.galasa:galasa-bom:0.33.0')
+
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'commons-io:commons-io:2.9.0'
 }

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,9 +1,9 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.32.0
+galasaVersion=0.33.0
 galasaSourceCompatibility=11
 galasaTargetCompatibility=11
 
-sourceMaven=https://repo.maven.apache.org/maven2/
+sourceMaven=https://development.galasa.dev/main/maven-repo/obr
 centralMaven=https://repo.maven.apache.org/maven2/
 targetMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Uplift plugins to 0.33.0
- Use the bom instead of specific versions of the managers.