### PR TITLE
Add SDV IVT to suite

### DIFF
--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -86,7 +86,7 @@ subprojects {
  //   }
 
     dependencies {
-        implementation platform('dev.galasa:galasa-bom:0.33.0')
+        implementation platform('dev.galasa:galasa-bom:0.36.0')
 
         compileOnly 'dev.galasa:dev.galasa'
         compileOnly 'dev.galasa:dev.galasa.framework'
@@ -106,6 +106,7 @@ subprojects {
         compileOnly 'dev.galasa:dev.galasa.java.windows.manager'
         compileOnly 'dev.galasa:dev.galasa.sem.manager'
         compileOnly 'dev.galasa:dev.galasa.cicsts.manager'
+        compileOnly 'dev.galasa:dev.galasa.sdv.manager'
         compileOnly 'dev.galasa:dev.galasa.zosprogram.manager'
         compileOnly 'dev.galasa:dev.galasa.githubissue.manager'
         compileOnly 'commons-logging:commons-logging:1.2'

--- a/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
+++ b/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>dev.galasa.inttests.obr</artifactId>
-	<version>0.33.0</version>
+	<version>0.36.0</version>
 	<packaging>galasa-obr</packaging>
 
 	<properties>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.inttests</artifactId>
-			<version>0.33.0</version>
+			<version>0.36.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/galasa-inttests-parent/dev.galasa.inttests/build.gradle
+++ b/galasa-inttests-parent/dev.galasa.inttests/build.gradle
@@ -5,10 +5,10 @@ plugins {
 
 description = 'Galasa Integration Tests'
 
-version = '0.33.0'
+version = '0.36.0'
 
 dependencies {
-    implementation platform('dev.galasa:galasa-bom:0.33.0')
+    implementation platform('dev.galasa:galasa-bom:0.36.0')
 
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'commons-io:commons-io:2.9.0'

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/AbstractSDVLocal.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/AbstractSDVLocal.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.inttests.sdv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.JsonObject;
+
+import dev.galasa.BeforeClass;
+import dev.galasa.ProductVersion;
+import dev.galasa.Test;
+import dev.galasa.cicsts.CicsRegion;
+import dev.galasa.cicsts.CicstsManagerException;
+import dev.galasa.cicsts.ICicsRegion;
+import dev.galasa.galasaecosystem.GalasaEcosystemManagerException;
+import dev.galasa.galasaecosystem.IGenericEcosystem;
+
+public abstract class AbstractSDVLocal {
+
+  @CicsRegion(cicsTag = "A")
+  public ICicsRegion cics;
+  
+  @BeforeClass
+    public void setProperties() throws GalasaEcosystemManagerException, CicstsManagerException {
+    // Setting these properties in the shadow ecosystem
+    getEcosystem().setCpsProperty("cicsts.provision.type", "DSE");
+    getEcosystem().setCpsProperty("cicsts.dse.tag.A.applid", cics.getApplid());
+    getEcosystem().setCpsProperty("cicsts.dse.tag.A.version", cics.getVersion().toString());
+    getEcosystem().setCpsProperty("cicsts.default.logon.initial.text", "HIT ENTER FOR LATEST STATUS");
+    getEcosystem().setCpsProperty("cicsts.default.logon.gm.text", "******\\(R)");
+
+  }
+        
+    @Test
+    public void testSDVIvtTest() throws Exception {
+
+        // Only run test if running on CICS 6.2+
+        if (!cics.getVersion().isEarlierThan(ProductVersion.v(750))) {
+
+            String runName = getEcosystem().submitRun(null, 
+                    null, 
+                    null, 
+                    "dev.galasa.sdv.manager.ivt",
+                    "dev.galasa.sdv.manager.ivt.SdvManagerIVT", 
+                    null, 
+                    null, 
+                    null, 
+                    null);
+            
+            JsonObject run = getEcosystem().waitForRun(runName);
+            
+            String result = run.get("result").getAsString();
+            
+            assertThat(result).as("The test indicates the test passes").isEqualTo("Passed");
+        } else {
+            // Just pass the test if running on earlier CICS versions
+            assertThat(true).isTrue();
+        }
+
+    }
+
+    abstract protected IGenericEcosystem getEcosystem();
+    
+}

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/local/SDVLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/local/SDVLocalJava11Ubuntu.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.inttests.sdv.local;
+
+import dev.galasa.Tags;
+import dev.galasa.Test;
+import dev.galasa.TestAreas;
+import dev.galasa.galasaecosystem.IGenericEcosystem;
+import dev.galasa.galasaecosystem.ILocalEcosystem;
+import dev.galasa.galasaecosystem.LocalEcosystem;
+import dev.galasa.inttests.sdv.AbstractSDVLocal;
+import dev.galasa.java.JavaVersion;
+import dev.galasa.java.ubuntu.IJavaUbuntuInstallation;
+import dev.galasa.java.ubuntu.JavaUbuntuInstallation;
+import dev.galasa.linux.ILinuxImage;
+import dev.galasa.linux.LinuxImage;
+import dev.galasa.linux.OperatingSystem;
+import dev.galasa.sem.SemTopology;
+import dev.galasa.zos.IZosImage;
+import dev.galasa.zos.ZosImage;
+
+@SemTopology
+@Test
+@TestAreas({"sdvManager","localecosystem","java11","ubuntu"})
+@Tags({"codecoverage"})
+public class SDVLocalJava11Ubuntu extends AbstractSDVLocal {
+
+    @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY")
+    public ILocalEcosystem ecosystem;
+    
+    @LinuxImage(operatingSystem = OperatingSystem.ubuntu)
+    public ILinuxImage linuxImage;
+    
+    @JavaUbuntuInstallation(javaVersion = JavaVersion.v11)
+    public IJavaUbuntuInstallation java;
+
+    @ZosImage
+    public IZosImage zosImage;
+
+    @Override
+    protected IGenericEcosystem getEcosystem() {
+        return this.ecosystem;
+    }
+
+}

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/local/isolated/SDVLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/sdv/local/isolated/SDVLocalJava11UbuntuIsolated.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.inttests.sdv.local.isolated;
+
+import dev.galasa.Test;
+import dev.galasa.TestAreas;
+import dev.galasa.galasaecosystem.IGenericEcosystem;
+import dev.galasa.galasaecosystem.ILocalEcosystem;
+import dev.galasa.galasaecosystem.LocalEcosystem;
+import dev.galasa.galasaecosystem.IsolationInstallation;
+import dev.galasa.inttests.sdv.AbstractSDVLocal;
+import dev.galasa.java.JavaVersion;
+import dev.galasa.java.ubuntu.IJavaUbuntuInstallation;
+import dev.galasa.java.ubuntu.JavaUbuntuInstallation;
+import dev.galasa.linux.ILinuxImage;
+import dev.galasa.linux.LinuxImage;
+import dev.galasa.linux.OperatingSystem;
+import dev.galasa.sem.SemTopology;
+import dev.galasa.zos.IZosImage;
+import dev.galasa.zos.ZosImage;
+
+@SemTopology
+@Test
+@TestAreas({"sdvManager","localecosystem","java11","ubuntu","isolated"})
+public class SDVLocalJava11UbuntuIsolated extends AbstractSDVLocal {
+
+    @LocalEcosystem(linuxImageTag = "PRIMARY", addDefaultZosImage = "PRIMARY", isolationInstallation = IsolationInstallation.Full)
+    public ILocalEcosystem ecosystem;
+    
+    @LinuxImage(operatingSystem = OperatingSystem.ubuntu, capabilities = "isolated")
+    public ILinuxImage linuxImage;
+    
+    @JavaUbuntuInstallation(javaVersion = JavaVersion.v11)
+    public IJavaUbuntuInstallation java;
+
+    @ZosImage
+    public IZosImage zosImage;
+
+    @Override
+    protected IGenericEcosystem getEcosystem() {
+        return this.ecosystem;
+    }
+    
+}

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/AllManagers.txt
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/AllManagers.txt
@@ -19,6 +19,7 @@ dev.galasa.liberty.manager
 dev.galasa.linux.manager
 dev.galasa.openstack.manager
 dev.galasa.phoenix2.manager
+dev.galasa.sdv.manager
 dev.galasa.selenium.manager
 dev.galasa.textscan.manager
 dev.galasa.vtp.manager

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,6 +1,6 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.33.0
+galasaVersion=0.36.0
 galasaSourceCompatibility=11
 galasaTargetCompatibility=11
 


### PR DESCRIPTION
Adding the SDV Manager IVT to the IVT test suite.

Provides the required CPS properties for the test to run.