### PR TITLE
allow main build to be called by workflow_dispatch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@
 name: Main build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Why?

To fix the error found here: https://github.com/galasa-dev/obr/actions/runs/11125875809/job/30915007341