### PR TITLE
Iss2018 - removing managers from text file that are no longer in isolated/mvp

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/AllManagers.txt
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/AllManagers.txt
@@ -15,14 +15,11 @@ dev.galasa.java.ubuntu.manager
 dev.galasa.java.windows.manager
 dev.galasa.jmeter.manager
 dev.galasa.kubernetes.manager
-dev.galasa.liberty.manager
 dev.galasa.linux.manager
 dev.galasa.openstack.manager
-dev.galasa.phoenix2.manager
 dev.galasa.sdv.manager
 dev.galasa.selenium.manager
 dev.galasa.textscan.manager
-dev.galasa.vtp.manager
 dev.galasa.windows.manager
 dev.galasa.zos.manager
 dev.galasa.zos3270.manager

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/MVPManagers.txt
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/resources/offlinebuild/MVPManagers.txt
@@ -3,4 +3,3 @@ dev.galasa.artifact.manager
 dev.galasa.http.manager
 dev.galasa.docker.manager
 dev.galasa.zos3270.manager
-dev.galasa.vtp.manager


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2018 - to fix failure in CompilationLocalOfflineJava11UbuntuMVP test. CompilationLocalOfflineJava11UbuntuIsolated test isn't failing (not sure why as VTP Manager has also been removed from Isolated) but thought I'd clean up the AllManagers.txt while I was making this change.