### PR TITLE
GitHub issue annotation

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDockerUbuntuLocal.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDockerUbuntuLocal.java
@@ -19,9 +19,7 @@ import dev.galasa.BeforeClass;
 import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.SetContentType;
 import dev.galasa.core.manager.StoredArtifactRoot;
-import dev.galasa.githubissue.GitHubIssue;
 
-@GitHubIssue( issue = "1366" )
 public abstract class AbstractDockerUbuntuLocal extends AbstractDocker {
 	
 	@StoredArtifactRoot

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/AbstractZosBatchLocalRSE.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/AbstractZosBatchLocalRSE.java
@@ -11,7 +11,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.Test;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
-import dev.galasa.githubissue.GitHubIssue;
 
 public abstract class AbstractZosBatchLocalRSE {
     

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/AbstractZosFileLocalRSE.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/AbstractZosFileLocalRSE.java
@@ -11,7 +11,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.Test;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
-import dev.galasa.githubissue.GitHubIssue;
 
 public abstract class AbstractZosFileLocalRSE {
 	

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/AbstractZosFileDatasetLocalRSE.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/AbstractZosFileDatasetLocalRSE.java
@@ -13,6 +13,7 @@ import dev.galasa.Test;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
 import dev.galasa.githubissue.GitHubIssue;
 
+@GitHubIssue( issue = "1961" )
 public abstract class AbstractZosFileDatasetLocalRSE {
     
     @Test

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/AbstractZosVSAMLocalRSE.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/AbstractZosVSAMLocalRSE.java
@@ -13,6 +13,7 @@ import dev.galasa.Test;
 import dev.galasa.galasaecosystem.IGenericEcosystem;
 import dev.galasa.githubissue.GitHubIssue;
 
+@GitHubIssue( issue = "1961" )
 public abstract class AbstractZosVSAMLocalRSE {
     
     @Test


### PR DESCRIPTION
## Why?

- Removing the `GitHubIssue` annotation from tests that no longer use it/the issue is closed therefore ignored
- Added the annotation to the RSE tests that are affected by the GitHub Issue 1961 so their result will be "Failed with Defects", so easier to pick out other failures in the daily regression run