### PR TITLE
Revert assertj-core dependency in inttests

### DIFF
--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -107,7 +107,7 @@ subprojects {
         compileOnly 'dev.galasa:dev.galasa.zosprogram.manager'
         compileOnly 'dev.galasa:dev.galasa.githubissue.manager'
         compileOnly 'commons-logging:commons-logging:1.2'
-        compileOnly 'org.assertj:assertj-core:3.16.1'
+        compileOnly 'org.assertj:assertj-core:3.11.1'
         compileOnly 'javax.validation:validation-api:2.0.1.Final'
     }
 }


### PR DESCRIPTION
## Why?

See https://github.com/galasa-dev/galasa/pull/54 and https://github.com/galasa-dev/galasa/pull/56

Reverting assertj-core dependency throughout Galasa to get integration tests back in a healthy state.