### PR TITLE
Iss2085 - Add extra check for forks running the workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,12 +12,24 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  NAMESPACE: galasa-dev
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
 
 jobs:
+  check-required-secrets-configured:
+    name: Check required secrets configured
+    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
+    with:
+      check_write_github_packages_username: 'true'
+      check_write_github_packages_token: 'true'
+    secrets:
+      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+
   build-integrationtests:
     name: Building the Integration Tests Repository
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
     
     steps:
       - name: Checkout Code
@@ -40,14 +52,14 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
       
-      - name: Build Integration Tests Gradle source code
+      - name: Build Integration Tests with Gradle
         run: |
           set -o pipefail
           gradle -b galasa-inttests-parent/build.gradle publish publishToMavenLocal --info \
           --no-daemon --console plain \
           -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
-          -PtargetMaven=${{github.workspace}}/repo 2>&1 | tee gradle-build.log
+          -PtargetMaven=${{ github.workspace }}/repo 2>&1 | tee gradle-build.log
         
       - name: Upload Gradle Build Log
         if: failure()
@@ -57,7 +69,7 @@ jobs:
           path: gradle-build.log
           retention-days: 7
       
-      - name: Building Integration Tests Maven source code
+      - name: Building Integration Tests Test Catalog with Maven
         run: |
             set -o pipefail
             mvn -f galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml deploy -X \
@@ -101,16 +113,20 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             baseVersion=latest
-            dockerRepository=ghcr.io
-            branch=main
+            dockerRepository=${{ env.REGISTRY }}
+            branch=${{ env.BRANCH }}
       
       - name: Recycle application in ArgoCD
+        # Skip this step for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
         env: 
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run main-inttests restart --kind Deployment --resource-name inttests-main --server argocd.galasa.dev
     
       - name: Wait for app health in ArgoCD
+        # Skip this step for forks
+        if: ${{ github.repository_owner == 'galasa-dev' }}
         env: 
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -35,7 +35,7 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
       
-      - name: Build Integration Tests Gradle source code
+      - name: Build Integration Tests with Gradle
         run: |
           set -o pipefail
           gradle -b galasa-inttests-parent/build.gradle publish publishToMavenLocal --info \
@@ -52,7 +52,7 @@ jobs:
           path: gradle-build.log
           retention-days: 7
 
-      - name: Building Integration Tests Maven source code
+      - name: Building Integration Tests Test Catalog with Maven
         run: |
             mvn -f galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml deploy -X \
             -Dgpg.skip=true \


### PR DESCRIPTION
## Why?

Recreating PR #215 as not all commits were signed.

For https://github.com/galasa-dev/projectmanagement/issues/2085

- Skip certain steps if the workflow is being run by a fork
- Check required secrets are configured before proceeding with the workflow
- Replace some hard coded values with environment variables