### PR TITLE
Iss2054 - Upgrade assertj-core version

### DIFF
--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -106,8 +106,8 @@ subprojects {
         compileOnly 'dev.galasa:dev.galasa.java.windows.manager'
         compileOnly 'dev.galasa:dev.galasa.zosprogram.manager'
         compileOnly 'dev.galasa:dev.galasa.githubissue.manager'
-        compileOnly 'commons-logging:commons-logging:1.2'
-        compileOnly 'org.assertj:assertj-core:3.11.1'
-        compileOnly 'javax.validation:validation-api:2.0.1.Final'
+        compileOnly 'commons-logging:commons-logging'
+        compileOnly 'org.assertj:assertj-core'
+        compileOnly 'javax.validation:validation-api'
     }
 }


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2054

- Remove explicit versions in build.gradle (use galasa-bom versions)
- This upgrades the assertj-core version
- Ensures consistent version of assertj-core used throughout Galasa