### PR TITLE
Update the Docker registry for the DockerLocalJava11Ubuntu test

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
@@ -36,10 +36,8 @@ public abstract class AbstractDocker {
 		getEcosystem().setCpsProperty("docker.engine.DKRTESTENGINE.max.slots", "3");
 
 		// TODO: remove hard coded values
-		getEcosystem().setCpsProperty("docker.default.registries", "HARBOR,PROXY");
-		getEcosystem().setCpsProperty("docker.registry.HARBOR.url", "https://harbor.galasa.dev");
-		getEcosystem().setCpsProperty("docker.registry.PROXY.url", "https://harbor.galasa.dev");
-		getEcosystem().setCpsProperty("docker.registry.PROXY.image.prefix", "docker_proxy_cache");
+		getEcosystem().setCpsProperty("docker.default.registries", "GHCR");
+		getEcosystem().setCpsProperty("docker.registry.GHCR.url", "https://ghcr.io");
 	}
 	
 	@Test


### PR DESCRIPTION
## Why?

Since completing story https://github.com/galasa-dev/projectmanagement/issues/1888 the images have been cleared out of the `docker_proxy_cache` namespace in Harbor, so this test has been failing to find the `httpd` image it requires. This change updates the test to use GHCR as the Docker registry to attempt to grab images from for testing.