### PR TITLE
Provide docker CPS properties to child ecosystem

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/docker/AbstractDocker.java
@@ -38,6 +38,7 @@ public abstract class AbstractDocker {
 		// TODO: remove hard coded values
 		getEcosystem().setCpsProperty("docker.default.registries", "GHCR");
 		getEcosystem().setCpsProperty("docker.registry.GHCR.url", "https://ghcr.io");
+		getEcosystem().setCpsProperty("docker.registry.GHCR.busybox.image", "galasa-dev/busybox:1.36.1");
 	}
 	
 	@Test


### PR DESCRIPTION
## Why?

As per this [PR in the Galasa repo](https://github.com/galasa-dev/galasa/pull/208), a fully qualified image name for the 'busybox' Docker image needs to be provided via CPS or the default of `library/busybox:latest` will be used. The image we want to use is at ghcr.io/galasa-dev/busybox:1.36.1 so we need to provide it to the child ecosystem in the test code so the DockerManagerIVT has access to it.