### PR TITLE
Iss2189 - Remove inttests that have been replaced by an IVT

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/ArtifactLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/ArtifactLocalJava11Ubuntu.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"artifactManager", "localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class ArtifactLocalJava11Ubuntu extends AbstractArtifactLocal {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/CoreLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/CoreLocalJava11Ubuntu.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"coreManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage","pipelinetest"})
 public class CoreLocalJava11Ubuntu extends AbstractCoreLocal {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/http/local/HttpLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/http/local/HttpLocalJava11Ubuntu.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"httpManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class HttpLocalJava11Ubuntu extends AbstractHttpLocal {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/ZosLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/ZosLocalJava11Ubuntu.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 public class ZosLocalJava11Ubuntu extends AbstractZosLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos3270/local/Zos3270LocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos3270/local/Zos3270LocalJava11Ubuntu.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zos3270Manager", "localecosystem","java11","ubuntu"})
 public class Zos3270LocalJava11Ubuntu extends AbstractZos3270Local {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/ZosTsoLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/ZosTsoLocalJava11Ubuntu.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 public class ZosTsoLocalJava11Ubuntu extends AbstractZosTsoLocal {
 


### PR DESCRIPTION
## Why?

Part of story https://github.com/galasa-dev/projectmanagement/issues/2189

I have set up a new CronJob on cicsk8s that runs the CICSTSManagerIVT, CEMTManagerIVT, CedaManagerIVT, Zos3270IVT, ZosManagerIVT and ZosManagerTSOCommandIVT on prod1 daily at 6am. This is the equivalent of the tests I have removed from the schedule by commenting out their `@Test` annotations (the only difference is these tests spin up a "local Galasa ecosystem" on a Linux VM and run the IVT there, instead of directly on prod1). 

I have removed these tests from the schedule on the regression-run to 1) reduce the load on the Linux VMs 2) reduce the number of tests using the old mechanism, to hopefully reduce the likelihood of tests getting stuck and holding up the whole regression-run.

For the same reasons, I have also removed the tests for the CoreManagerIVT, ArtifactManagerIVT and HttpManagerIVT, as these have been running successfully on ecosystem1.

