### PR TITLE
Iss2189 - Remove z/OS inttests from schedule as there are equivalent IVTs

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/isolated/ZosLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/isolated/ZosLocalJava11UbuntuIsolated.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosLocalJava11UbuntuIsolated extends AbstractZosLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/mvp/ZosLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zos/local/mvp/ZosLocalJava11UbuntuMvp.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosLocalJava11UbuntuMvp extends AbstractZosLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuRse.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 //@Tags({"codecoverage"}) - disabled until rse stable
 public class ZosBatchLocalJava11UbuntuRse extends AbstractZosBatchLocalRSE {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/ZosBatchLocalJava11UbuntuZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class ZosBatchLocalJava11UbuntuZosmf extends AbstractZosBatchLocalZosmf {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/isolated/ZosBatchLocalJava11UbuntuIsolatedRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/isolated/ZosBatchLocalJava11UbuntuIsolatedRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosBatchLocalJava11UbuntuIsolatedRse extends AbstractZosBatchLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/isolated/ZosBatchLocalJava11UbuntuIsolatedZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/isolated/ZosBatchLocalJava11UbuntuIsolatedZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosBatchLocalJava11UbuntuIsolatedZosmf extends AbstractZosBatchLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/mvp/ZosBatchLocalJava11UbuntuMvpRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/mvp/ZosBatchLocalJava11UbuntuMvpRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosBatchLocalJava11UbuntuMvpRse extends AbstractZosBatchLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/mvp/ZosBatchLocalJava11UbuntuMvpZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosBatch/local/mvp/ZosBatchLocalJava11UbuntuMvpZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosBatchLocalJava11UbuntuMvpZosmf extends AbstractZosBatchLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuRse.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 //@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosFileLocalJava11UbuntuRse extends AbstractZosFileLocalRSE {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/ZosFileLocalJava11UbuntuZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class ZosFileLocalJava11UbuntuZosmf extends AbstractZosFileLocalZosmf {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/isolated/ZosFileLocalJava11UbuntuIsolatedRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/isolated/ZosFileLocalJava11UbuntuIsolatedRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosFileLocalJava11UbuntuIsolatedRse extends AbstractZosFileLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/isolated/ZosFileLocalJava11UbuntuIsolatedZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/isolated/ZosFileLocalJava11UbuntuIsolatedZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosFileLocalJava11UbuntuIsolatedZosmf extends AbstractZosFileLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/mvp/ZosFileLocalJava11UbuntuMvpRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/mvp/ZosFileLocalJava11UbuntuMvpRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosFileLocalJava11UbuntuMvpRse extends AbstractZosFileLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/mvp/ZosFileLocalJava11UbuntuMvpZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFile/local/mvp/ZosFileLocalJava11UbuntuMvpZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosFileLocalJava11UbuntuMvpZosmf extends AbstractZosFileLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuRse.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 //@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosFileDatasetLocalJava11UbuntuRse extends AbstractZosFileDatasetLocalRSE {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/ZosFileDatasetLocalJava11UbuntuZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class ZosFileDatasetLocalJava11UbuntuZosmf extends AbstractZosFileDatasetLocalZosmf {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/isolated/ZosFileDatasetLocalJava11UbuntuIsolatedRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/isolated/ZosFileDatasetLocalJava11UbuntuIsolatedRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosFileDatasetLocalJava11UbuntuIsolatedRse extends AbstractZosFileDatasetLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/isolated/ZosFileDatasetLocalJava11UbuntuIsolatedZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/isolated/ZosFileDatasetLocalJava11UbuntuIsolatedZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosFileDatasetLocalJava11UbuntuIsolatedZosmf extends AbstractZosFileDatasetLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/mvp/ZosFileDatasetLocalJava11UbuntuMvpRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/mvp/ZosFileDatasetLocalJava11UbuntuMvpRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosFileDatasetLocalJava11UbuntuMvpRse extends AbstractZosFileDatasetLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/mvp/ZosFileDatasetLocalJava11UbuntuMvpZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosFileDataset/local/mvp/ZosFileDatasetLocalJava11UbuntuMvpZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosFileDatasetLocalJava11UbuntuMvpZosmf extends AbstractZosFileDatasetLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/isolated/ZosTsoLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/isolated/ZosTsoLocalJava11UbuntuIsolated.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosTsoLocalJava11UbuntuIsolated extends AbstractZosTsoLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/mvp/ZosTsoLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosTso/local/mvp/ZosTsoLocalJava11UbuntuMvp.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosTsoLocalJava11UbuntuMvp extends AbstractZosTsoLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuRse.java
@@ -20,7 +20,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 //@Tags({"codecoverage"}) disabled until RSE stable
 public class ZosVSAMLocalJava11UbuntuRse extends AbstractZosVSAMLocalRSE {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/ZosVSAMLocalJava11UbuntuZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class ZosVSAMLocalJava11UbuntuZosmf extends AbstractZosVSAMLocalZosmf {

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/isolated/ZosVSAMLocalJava11UbuntuIsolatedRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/isolated/ZosVSAMLocalJava11UbuntuIsolatedRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosVSAMLocalJava11UbuntuIsolatedRse extends AbstractZosVSAMLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/isolated/ZosVSAMLocalJava11UbuntuIsolatedZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/isolated/ZosVSAMLocalJava11UbuntuIsolatedZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","isolated"})
 public class ZosVSAMLocalJava11UbuntuIsolatedZosmf extends AbstractZosVSAMLocalZosmf {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/mvp/ZosVSAMLocalJava11UbuntuMvpRse.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/mvp/ZosVSAMLocalJava11UbuntuMvpRse.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosVSAMLocalJava11UbuntuMvpRse extends AbstractZosVSAMLocalRSE {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/mvp/ZosVSAMLocalJava11UbuntuMvpZosmf.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/zosVSAM/local/mvp/ZosVSAMLocalJava11UbuntuMvpZosmf.java
@@ -21,7 +21,7 @@ import dev.galasa.linux.OperatingSystem;
 import dev.galasa.zos.IZosImage;
 import dev.galasa.zos.ZosImage;
 
-@Test
+// @Test
 @TestAreas({"zosManager","localecosystem","java11","ubuntu","mvp"})
 public class ZosVSAMLocalJava11UbuntuMvpZosmf extends AbstractZosVSAMLocalZosmf {
 


### PR DESCRIPTION
## Why?

Part of story https://github.com/galasa-dev/projectmanagement/issues/2189

I have set up a new CronJob on cicsk8s that runs the ZosFileManagerIVT, ZosFileDatasetManagerIVT, ZosVSAMManageIVT and ZosBatchManagerIVT on prod1 daily at 6am, with both the RSE API and z/OS MF implementations.

I have removed the equivalent inttests from the schedule by commenting out their @Test annotations, as we are trying to remove as many tests as possible that still require the local Galasa ecosystem install on the Linux VM.

I have removed the *Isolated and *Mvp variations of the tests also even though the IVTs can't test this - I discussed with @techcobweb that the Isolated and MVP tests should really be local Galasa tests, not remote ones on a Galasa service, as the Isolated/MVP zip can only be used locally. Story https://github.com/galasa-dev/projectmanagement/issues/2190 covers making an equivalent for these.