### PR TITLE
Iss2190 - remove SimbankLocalJava11Ubuntu

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/SimBankLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/SimBankLocalJava11Ubuntu.java
@@ -18,7 +18,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"simplatform","localecosystem","java11","ubuntu"})
 @Tags({"codecoverage"})
 public class SimBankLocalJava11Ubuntu extends AbstractSimBankLocal {


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

Part of the efforts to replace all the old inttests that rely on the Linux VMs with new tests.

- This PR removes the SimbankLocalJava11Ubuntu test from the inttest schedule.  It has been replaced by https://github.com/galasa-dev/simplatform/blob/main/.github/workflows/test.yaml so this inttest is no longer needed.