### PR TITLE
Remove Isolated and MVP tests for the Core, Artifact and Simbank

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/isolated/ArtifactLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/isolated/ArtifactLocalJava11UbuntuIsolated.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"artifactManager", "localecosystem","java11","ubuntu","isolated"})
 public class ArtifactLocalJava11UbuntuIsolated extends AbstractArtifactLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/mvp/ArtifactLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/artifact/local/mvp/ArtifactLocalJava11UbuntuMvp.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"artifactManager", "localecosystem","java11","ubuntu","mvp"})
 public class ArtifactLocalJava11UbuntuMvp extends AbstractArtifactLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/isolated/CoreLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/isolated/CoreLocalJava11UbuntuIsolated.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"coreManager","localecosystem","java11","ubuntu","isolated"})
 public class CoreLocalJava11UbuntuIsolated extends AbstractCoreLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/mvp/CoreLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/core/local/mvp/CoreLocalJava11UbuntuMvp.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"coreManager","localecosystem","java11","ubuntu","mvp"})
 public class CoreLocalJava11UbuntuMvp extends AbstractCoreLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/isolated/SimBankLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/isolated/SimBankLocalJava11UbuntuIsolated.java
@@ -18,7 +18,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"simplatform","localecosystem","java11","ubuntu","isolated"})
 public class SimBankLocalJava11UbuntuIsolated extends AbstractSimBankLocal {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/mvp/SimBankLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/simbank/local/mvp/SimBankLocalJava11UbuntuMvp.java
@@ -18,7 +18,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"simplatform","localecosystem","java11","ubuntu","mvp"})
 public class SimBankLocalJava11UbuntuMvp extends AbstractSimBankLocal {
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

Remove Isolated and MVP tests for the Core, Artifact and Simbank managers as they have been replicated in https://github.com/galasa-dev/isolated/pull/105

We will actually delete these test files at some point but for now while we're still converting them, its easier to be able to see the old tests.