### PR TITLE
Removing old Compilation inttests

### DIFF
--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/offline/isolated/CompilationLocalOfflineJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/offline/isolated/CompilationLocalOfflineJava11UbuntuIsolated.java
@@ -22,7 +22,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"compilation","localecosystem","java11","ubuntu","isolated"})
 public class CompilationLocalOfflineJava11UbuntuIsolated extends AbstractCompilationLocalOffline {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/offline/mvp/CompilationLocalOfflineJava11UbuntuMVP.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/offline/mvp/CompilationLocalOfflineJava11UbuntuMVP.java
@@ -22,7 +22,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"compilation","localecosystem","java11","ubuntu","mvp"})
 public class CompilationLocalOfflineJava11UbuntuMVP extends AbstractCompilationLocalOffline {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/offline/isolated/CompilationLocalJava11UbuntuIsolated.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/offline/isolated/CompilationLocalJava11UbuntuIsolated.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"compilation","localecosystem","java11","ubuntu","isolated"})
 public class CompilationLocalJava11UbuntuIsolated extends AbstractCompilationLocalSimBankOffline {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/offline/mvp/CompilationLocalJava11UbuntuMvp.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/offline/mvp/CompilationLocalJava11UbuntuMvp.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.ILinuxImage;
 import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
-@Test
+// @Test
 @TestAreas({"compilation","localecosystem","java11","ubuntu","mvp"})
 public class CompilationLocalJava11UbuntuMvp extends AbstractCompilationLocalSimBankOffline {
 

--- a/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/online/CompilationLocalJava11Ubuntu.java
+++ b/galasa-inttests-parent/dev.galasa.inttests/src/main/java/dev/galasa/inttests/compilation/simbank/local/online/CompilationLocalJava11Ubuntu.java
@@ -19,7 +19,7 @@ import dev.galasa.linux.LinuxImage;
 import dev.galasa.linux.OperatingSystem;
 
 
-@Test
+// @Test
 @TestAreas({"compilation","localecosystem","java11","ubuntu"})
 public class CompilationLocalJava11Ubuntu extends AbstractCompilationLocalSimBank {
 


### PR DESCRIPTION
## Why?

test: Removing old Compilation inttests that are no longer needed as they have been replaced by equivalent IVTs