### PR TITLE
Iss2369 - Uplift gradle version used in build workflow to 9.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,13 +48,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
       
       - name: Build Integration Tests with Gradle
+        working-directory: galasa-inttests-parent
         run: |
           set -o pipefail
-          gradle -b galasa-inttests-parent/build.gradle publish publishToMavenLocal --info \
+          gradle publish publishToMavenLocal --info \
           --no-daemon --console plain \
           -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -32,13 +32,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
       
       - name: Build Integration Tests with Gradle
+        working-directory: galasa-inttests-parent
         run: |
           set -o pipefail
-          gradle -b galasa-inttests-parent/build.gradle publish publishToMavenLocal --info \
+          gradle publish publishToMavenLocal --info \
           --no-daemon --console plain \
           -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \

--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -26,10 +26,6 @@ subprojects {
         version = galasaVersion
     }
 
-    // JDK compatibility
-    sourceCompatibility = galasaSourceCompatibility
-    targetCompatibility = galasaTargetCompatibility
-
  //   ext.isReleaseVersion = false
 
  //   tasks.withType(Sign) {
@@ -41,8 +37,10 @@ subprojects {
     }
 
     java {
-        // withJavadocJar()
-        // withSourcesJar()
+        // JDK compatibility
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
     }
     
     tasks.withType(Javadoc) {

--- a/galasa-inttests-parent/dev.galasa.inttests/build.gradle
+++ b/galasa-inttests-parent/dev.galasa.inttests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '5.3.0'
+    id 'biz.aQute.bnd.builder' version '7.1.0'
     id 'dev.galasa.tests'
 }
 

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,8 +1,6 @@
 galasaGroup=dev.galasa
 galasaName=galasa
 galasaVersion=0.44.0
-galasaSourceCompatibility=11
-galasaTargetCompatibility=11
 
 sourceMaven=https://development.galasa.dev/main/maven-repo/obr
 centralMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2369

## Changes

- Uplift Gradle version used in GitHub Actions workflows to 9.0.0 from 8.9.
- Uplift biz.aQute.bnd dependencies to version 7.1.0 as this version of the plugin is compatible with Gradle 9.0.0.
- Remove use of -b flag to point to location of build.gradle file as this has been removed in Gradle 9.
- Replace sourceCompatibility and targetCompatibility with Java toolchains as this is the recommended way to set the Java version.