### PR TITLE
Update development version to 0.48.0

### DIFF
--- a/galasa-inttests-parent/build.gradle
+++ b/galasa-inttests-parent/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'dev.galasa.githash' version '0.47.0' apply false
-    id 'dev.galasa.testcatalog' version '0.47.0' apply false
-    id 'dev.galasa.tests' version '0.47.0' apply false
+    id 'dev.galasa.githash' version '0.48.0' apply false
+    id 'dev.galasa.testcatalog' version '0.48.0' apply false
+    id 'dev.galasa.tests' version '0.48.0' apply false
 }
 
 subprojects {
@@ -84,7 +84,7 @@ subprojects {
  //   }
 
     dependencies {
-        implementation platform('dev.galasa:galasa-bom:0.47.0')
+        implementation platform('dev.galasa:galasa-bom:0.48.0')
 
         compileOnly 'dev.galasa:dev.galasa'
         compileOnly 'dev.galasa:dev.galasa.framework'

--- a/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
+++ b/galasa-inttests-parent/dev.galasa.inttests.obr/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>dev.galasa.inttests.obr</artifactId>
-	<version>0.47.0</version>
+	<version>0.48.0</version>
 	<packaging>galasa-obr</packaging>
 
 	<properties>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>dev.galasa</groupId>
 			<artifactId>dev.galasa.inttests</artifactId>
-			<version>0.47.0</version>
+			<version>0.48.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>dev.galasa</groupId>
 				<artifactId>galasa-maven-plugin</artifactId>
-				<version>0.47.0</version>
+				<version>0.48.0</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/galasa-inttests-parent/dev.galasa.inttests/build.gradle
+++ b/galasa-inttests-parent/dev.galasa.inttests/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa Integration Tests'
 
-version = '0.47.0'
+version = '0.48.0'
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/galasa-inttests-parent/gradle.properties
+++ b/galasa-inttests-parent/gradle.properties
@@ -1,6 +1,6 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.47.0
+galasaVersion=0.48.0
 
 sourceMaven=https://development.galasa.dev/main/maven-repo/obr
 centralMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2528. 

## Changes
- [x] Bumps the development version of Galasa to 0.48.0